### PR TITLE
fix: Update shred and specs after SystemData refactor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs-hierarchy"
-version = "0.1.0-alpha7"
+version = "0.1.0-alpha8"
 authors = ["Aceeri <conmcclusk@gmail.com>", "Rhuagh <seamonr@gmail.com>"]
 repository = "https://github.com/rustgd/specs-hierarchy.git"
 homepage = "https://github.com/rustgd/specs-hierarchy.git"
@@ -14,7 +14,7 @@ keywords = ["specs", "scenegraph", "hierarchy"]
 
 [dependencies]
 hibitset = "0.5"
-specs = { version = "0.11.0-alpha6" }
-shred = { version = "0.7.0-alpha5" }
+specs = { version = "0.11.0-alpha7" }
+shred = { version = "0.7.0-alpha6" }
 shrev = { version = "1.0.0" }
-shred-derive = { version = "0.5.0-alpha1" }
+shred-derive = { version = "0.5.0-alpha2" }

--- a/examples/sort.rs
+++ b/examples/sort.rs
@@ -38,10 +38,10 @@ fn main() {
 
     {
         let mut parents = world.write_storage::<Parent>();
-        parents.insert(e1, Parent { entity: e5 });
-        parents.insert(e3, Parent { entity: e1 });
-        parents.insert(e4, Parent { entity: e5 });
-        parents.insert(e5, Parent { entity: e2 });
+        parents.insert(e1, Parent { entity: e5 }).unwrap();
+        parents.insert(e3, Parent { entity: e1 }).unwrap();
+        parents.insert(e4, Parent { entity: e5 }).unwrap();
+        parents.insert(e5, Parent { entity: e2 }).unwrap();
     }
 
     dispatcher.dispatch(&mut world.res);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,10 @@
 ///
 /// ## Usage
 ///
-/// ```
+/// ```rust
+/// # extern crate specs;
+/// # extern crate specs_hierarchy;
+///
 /// use specs::prelude::{Component, DenseVecStorage, Entity, FlaggedStorage};
 /// use specs_hierarchy::{Hierarchy, Parent as HParent};
 ///
@@ -34,6 +37,8 @@
 ///         self.entity
 ///     }
 /// }
+///
+/// # fn main() {}
 /// ```
 ///
 


### PR DESCRIPTION
Do not merge before specs+shred have been released and patch section is removed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/specs-hierarchy/2)
<!-- Reviewable:end -->
