### PR TITLE
Improve signature of the `children` function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,8 +149,8 @@ impl<P> Hierarchy<P> {
     }
 
     /// Get the children of a specific entity.
-    pub fn children(&self, entity: Entity) -> Option<&[Entity]> {
-        self.children.get(&entity).map(|vec| vec.as_slice())
+    pub fn children(&self, entity: Entity) -> &[Entity] {
+        self.children.get(&entity).map(|vec| vec.as_slice()).unwrap_or(&[])
     }
 
     /// Get the parent of a specific entity


### PR DESCRIPTION
`Option` in this signature feels extraneous.  We're returning a set, so if there is no set then we can just return an empty set.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/specs-hierarchy/4)
<!-- Reviewable:end -->
