### PR TITLE
Bump specs version to 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["specs", "scenegraph", "hierarchy"]
 
 [dependencies]
 hibitset = "0.5"
-specs = "0.11"
+specs = "0.12"
 shred = "0.7"
 shrev = "1.0"
 shred-derive = "0.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -446,8 +446,8 @@ where
 mod tests {
 
     use super::{Hierarchy, HierarchyEvent, HierarchySystem, Parent as PParent};
-    use specs::prelude::{Component, DenseVecStorage, Entity, FlaggedStorage, ReaderId, RunNow,
-                         System, World};
+    use specs::prelude::{Builder, Component, DenseVecStorage, Entity, FlaggedStorage, ReaderId,
+                         RunNow, System, World};
 
     struct Parent {
         entity: Entity,


### PR DESCRIPTION
Increases specs dependency version to avoid type collision when using specs 0.12 in Amethyst.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/specs-hierarchy/5)
<!-- Reviewable:end -->
