### PR TITLE
v0.3.1, added features 'parallel' and 'nightly'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "specs-hierarchy"
-version = "0.2.1"
+version = "0.3.1"
 authors = ["Aceeri <conmcclusk@gmail.com>", "Rhuagh <seamonr@gmail.com>"]
 repository = "https://github.com/rustgd/specs-hierarchy.git"
 homepage = "https://github.com/rustgd/specs-hierarchy.git"
@@ -13,8 +13,13 @@ description = "Scene graph type hierarchy abstraction for use with specs"
 keywords = ["specs", "scenegraph", "hierarchy"]
 
 [dependencies]
-hibitset = "0.5"
-specs = "0.14"
-shred = "0.7"
+hibitset = { version = "0.5", default-features = false }
+specs = { version = "0.14", default-features = false }
+shred = { version = "0.7", default-features = false }
 shrev = "1.0"
 shred-derive = "0.5"
+
+[features]
+default = ["parallel"]
+parallel = ["specs/parallel", "shred/parallel", "hibitset/parallel"]
+nightly = ["specs/nightly", "shred/nightly"]


### PR DESCRIPTION
- This PR adds features `parallel` and `nightly`, with `parallel` enabled by default.
- This mirrors the features in `specs` (see [Cargo.toml](https://github.com/slide-rs/specs/blob/master/Cargo.toml#L40)).
- This allows for `specs-hierarchy` to work in WASM environments by disabling default features, e.g.:

    ```toml
    specs-hierarchy = { version = "0.3.1", default-features = false }
    ```

Also I bumped the version up to `0.3.1` for consistency with the version on crates.io

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rustgd/specs-hierarchy/11)
<!-- Reviewable:end -->
