### PR TITLE
Maintenance/18/ongoing code maintenance

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,9 @@ description = "Scene graph type hierarchy abstraction for use with specs"
 keywords = ["specs", "scenegraph", "hierarchy"]
 
 [dependencies]
-hibitset = { version = "0.6", default-features = false }
-specs = { version = "0.16", default-features = false, features = ["shred-derive"] }
-shrev = "1.1"
+hibitset = { version = "0.6.2", default-features = false }
+specs = { version = "0.16.0", default-features = false, features = ["shred-derive"] }
+shrev = "1.1.1"
 
 [features]
 default = ["parallel"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,9 @@ keywords = ["specs", "scenegraph", "hierarchy"]
 
 [dependencies]
 hibitset = { version = "0.6", default-features = false }
-specs = { version = "0.15", default-features = false }
-shred = { version = "0.9", default-features = false }
+specs = { version = "0.16", default-features = false, features = ["shred-derive"] }
 shrev = "1.1"
-shred-derive = "0.6"
 
 [features]
 default = ["parallel"]
-parallel = ["specs/parallel", "shred/parallel", "hibitset/parallel"]
-nightly = ["specs/nightly", "shred/nightly"]
+parallel = ["specs/parallel", "hibitset/parallel"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,9 +42,6 @@
 /// ```
 ///
 extern crate hibitset;
-extern crate shred;
-#[macro_use]
-extern crate shred_derive;
 extern crate shrev;
 extern crate specs;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ impl<P> Hierarchy<P> {
     ///
     /// This does not include the parent entity you pass in. Parents are guaranteed to be
     /// prior to their children.
-    pub fn all_children_iter<'a>(&'a self, entity: Entity) -> SubHierarchyIterator<'a, P> {
+    pub fn all_children_iter(&self, entity: Entity) -> SubHierarchyIterator<'_, P> {
         SubHierarchyIterator::new(self, entity)
     }
 
@@ -289,7 +289,7 @@ impl<P> Hierarchy<P> {
                         .min()
                         .cloned()
                 })
-                .unwrap_or(self.sorted.len());
+                .unwrap_or_else(|| self.sorted.len());
             self.entities.insert(entity.id(), insert_index);
             if insert_index >= self.sorted.len() {
                 self.sorted.push(entity);


### PR DESCRIPTION
Closes #18.

`shred` and `shred-derive` are removed as they are re-exported by `specs`.